### PR TITLE
Remove HEALTHCHECK temporaly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
 ADD rootfs /
 
 # Add *.softonic.com certificate
-RUN echo "symantec.crt" >> /usr/share/ca-certificates.conf \
+RUN echo "symantec.crt" >> /etc/ca-certificates.conf \
     && update-ca-certificates
 
 # Extra folder for storing SQL Errors. TODO: Change this to another log strategy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,6 @@ RUN mkdir -p /var/log/sql/ && chmod 0777 /var/log/sql/ \
     && sed -i 's/#Require ip 192.0.2.0\/24/Require ip 10.0.0.0\/8 172.16.0.0\/12 192.168.0.0\/16/' /etc/apache2/mods-enabled/status.conf
 
 # Auto-health check to the root page
-HEALTHCHECK --interval=5s --timeout=2s \
-  CMD curl -f -A "Docker-HealthCheck/v.x (https://docs.docker.com/engine/reference/builder/#healthcheck)" http://localhost/ || exit 1
+# Removed until docker hub support HEALTHCHECK feature
+# HEALTHCHECK --interval=5s --timeout=2s \
+#  CMD curl -f -A "Docker-HealthCheck/v.x (https://docs.docker.com/engine/reference/builder/#healthcheck)" http://localhost/ || exit 1


### PR DESCRIPTION
Currently the HEALTHCHECK is not available in Docker Hub and we need the last build to work as expected.
